### PR TITLE
fix: add dynamodb permissions and improve configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ env:
   AWS_REGION: ${{ vars.AWS_REGION }}
   ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
   TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
-  GITHUB_REPO: ${{ vars.GITHUB_REPO }}
   TF_WORKSPACE: ${{ vars.ENVIRONMENT }}
 
 jobs:
@@ -87,7 +86,7 @@ jobs:
       run: terraform plan -input=false -out=tfplan
       env:
         TF_VAR_aws_region: ${{ env.AWS_REGION }}
-        TF_VAR_github_repo: ${{ env.GITHUB_REPO }}
+        TF_VAR_github_repo: ${{ github.repository }}
         TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
         TF_VAR_tf_state_bucket: ${{ env.TF_STATE_BUCKET }}
         TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}
@@ -98,7 +97,7 @@ jobs:
       run: terraform apply -auto-approve tfplan
       env:
         TF_VAR_aws_region: ${{ env.AWS_REGION }}
-        TF_VAR_github_repo: ${{ env.GITHUB_REPO }}
+        TF_VAR_github_repo: ${{ github.repository }}
         TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
         TF_VAR_tf_state_bucket: ${{ env.TF_STATE_BUCKET }}
         TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,17 @@ on:
     branches: [ main ]
 
 env:
-  AWS_REGION: us-east-2
-  ECR_REPOSITORY: ncsoccer-scraper
-  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-  TF_WORKSPACE: dev
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+  TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
+  GITHUB_REPO: ${{ vars.GITHUB_REPO }}
+  TF_WORKSPACE: ${{ vars.ENVIRONMENT }}
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    environment: dev
+    environment: ${{ vars.ENVIRONMENT }}
     permissions:
       contents: read
       id-token: write
@@ -51,7 +52,7 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    environment: dev
+    environment: ${{ vars.ENVIRONMENT }}
     permissions:
       contents: read
       id-token: write
@@ -75,7 +76,7 @@ jobs:
       working-directory: ./terraform/app
       run: |
         terraform init \
-          -backend-config="bucket=ncsh-terraform-state" \
+          -backend-config="bucket=${{ env.TF_STATE_BUCKET }}" \
           -backend-config="key=app/terraform.tfstate" \
           -backend-config="region=${{ env.AWS_REGION }}"
       env:
@@ -86,9 +87,9 @@ jobs:
       run: terraform plan -input=false -out=tfplan
       env:
         TF_VAR_aws_region: ${{ env.AWS_REGION }}
-        TF_VAR_github_repo: "mzakany23/ncsh"
+        TF_VAR_github_repo: ${{ env.GITHUB_REPO }}
         TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
-        TF_VAR_tf_state_bucket: "ncsh-terraform-state"
+        TF_VAR_tf_state_bucket: ${{ env.TF_STATE_BUCKET }}
         TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}
 
     - name: Terraform Apply (App)
@@ -97,9 +98,9 @@ jobs:
       run: terraform apply -auto-approve tfplan
       env:
         TF_VAR_aws_region: ${{ env.AWS_REGION }}
-        TF_VAR_github_repo: "mzakany23/ncsh"
+        TF_VAR_github_repo: ${{ env.GITHUB_REPO }}
         TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
-        TF_VAR_tf_state_bucket: "ncsh-terraform-state"
+        TF_VAR_tf_state_bucket: ${{ env.TF_STATE_BUCKET }}
         TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}
 
     - name: Test Lambda Function

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,19 +83,23 @@ jobs:
 
     - name: Terraform Plan (App)
       working-directory: ./terraform/app
-      run: terraform plan
+      run: terraform plan -input=false -out=tfplan
       env:
         TF_VAR_aws_region: ${{ env.AWS_REGION }}
+        TF_VAR_github_repo: "mzakany23/ncsh"
         TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
+        TF_VAR_tf_state_bucket: "ncsh-terraform-state"
         TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}
 
     - name: Terraform Apply (App)
       if: github.ref == 'refs/heads/main'
       working-directory: ./terraform/app
-      run: terraform apply -auto-approve
+      run: terraform apply -auto-approve tfplan
       env:
         TF_VAR_aws_region: ${{ env.AWS_REGION }}
+        TF_VAR_github_repo: "mzakany23/ncsh"
         TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
+        TF_VAR_tf_state_bucket: "ncsh-terraform-state"
         TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}
 
     - name: Test Lambda Function

--- a/terraform/app/terraform.tfvars.example
+++ b/terraform/app/terraform.tfvars.example
@@ -1,5 +1,14 @@
-aws_region         = "us-east-2"
-github_repo        = "mzakany23/ncsh"
-ecr_repository_name = "ncsoccer-scraper"
-tf_state_bucket    = "ncsh-terraform-state"
-data_bucket_name   = "ncsh-app-data"
+# AWS Region for resources
+aws_region = "us-east-2"
+
+# GitHub repository in format owner/repo
+github_repo = "owner/repo"
+
+# ECR repository name for Lambda container
+ecr_repository_name = "your-ecr-repo-name"
+
+# S3 bucket for Terraform state (must be globally unique)
+tf_state_bucket = "your-terraform-state-bucket"
+
+# S3 bucket for application data (must be globally unique)
+data_bucket_name = "your-app-data-bucket"

--- a/terraform/app/terraform.tfvars.example
+++ b/terraform/app/terraform.tfvars.example
@@ -1,0 +1,5 @@
+aws_region         = "us-east-2"
+github_repo        = "mzakany23/ncsh"
+ecr_repository_name = "ncsoccer-scraper"
+tf_state_bucket    = "ncsh-terraform-state"
+data_bucket_name   = "ncsh-app-data"


### PR DESCRIPTION
This PR includes several improvements to the infrastructure and workflow: 1. Add DynamoDB permissions: - Add table for Terraform state locking - Grant necessary permissions to GitHub Actions roles - Configure backend to use state locking 2. Improve configuration management: - Move all configuration to GitHub environment variables - Use built-in github.repository context - Add example tfvars file for local development - Document required variables 3. Optimize Terraform operations: - Add -input=false to prevent hanging - Save plan to file for consistent apply - Use environment variables instead of var-file in CI