### PR TITLE
fix: add S3 bucket policy permissions

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -135,7 +135,9 @@ resource "aws_iam_role_policy" "github_actions_s3" {
       {
         Effect = "Allow"
         Action = [
-          "s3:ListBucket"
+          "s3:ListBucket",
+          "s3:GetBucketPolicy",
+          "s3:PutBucketPolicy"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn,


### PR DESCRIPTION
## Changes\n\n- Added s3:GetBucketPolicy and s3:PutBucketPolicy permissions to GitHub Actions IAM role\n- Fixes Terraform plan error related to S3 bucket policy access\n\n## Testing\n- [ ] Terraform plan succeeds without S3 bucket policy permission errors\n- [ ] GitHub Actions workflow can access S3 bucket policies