### PR TITLE
feat: add setup module for bootstrap resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Before using the automated CI/CD pipeline, you must manually set up the required
 
 1. Configure AWS credentials locally:
    ```bash
-   export AWS_PROFILE=mzakany
+   export AWS_PROFILE=<your-profile-name>
    ```
 
 2. Apply the setup module to create bootstrap resources:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 A robust web scraper for collecting North Coast soccer game schedules. Built with Scrapy and deployable to AWS Lambda.
 
+## Initial Setup
+
+Before using the automated CI/CD pipeline, you must manually set up the required AWS infrastructure:
+
+1. Configure AWS credentials locally:
+   ```bash
+   export AWS_PROFILE=mzakany
+   ```
+
+2. Apply the setup module to create bootstrap resources:
+   ```bash
+   cd terraform/setup
+   terraform init
+   terraform apply
+   ```
+
+   This creates:
+   - S3 bucket for Terraform state
+   - DynamoDB table for state locking
+   - GitHub Actions OIDC provider
+   - Base IAM role and policies for GitHub Actions
+
+3. Note the outputs, you'll need them for GitHub configuration:
+   - `github_actions_role_arn`: Use this as AWS_ROLE_ARN in GitHub secrets
+
+After these manual steps are complete, the GitHub Actions automation will have the necessary permissions to manage all other infrastructure.
+
 ## Features (v1.0.0)
 
 - **Schedule Scraping**

--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -137,7 +137,15 @@ resource "aws_iam_role_policy" "github_actions_s3" {
         Action = [
           "s3:ListBucket",
           "s3:GetBucketPolicy",
-          "s3:PutBucketPolicy"
+          "s3:PutBucketPolicy",
+          "s3:GetBucketVersioning",
+          "s3:GetBucketAcl",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetBucketPublicAccessBlock",
+          "s3:PutBucketPublicAccessBlock",
+          "s3:GetBucketLogging",
+          "s3:GetBucketTagging",
+          "s3:GetBucketLocation"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn,
@@ -148,7 +156,11 @@ resource "aws_iam_role_policy" "github_actions_s3" {
         Effect = "Allow"
         Action = [
           "s3:GetObject",
-          "s3:PutObject"
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetObjectVersion",
+          "s3:GetObjectAcl",
+          "s3:PutObjectAcl"
         ]
         Resource = [
           "${aws_s3_bucket.terraform_state.arn}/*",
@@ -227,3 +239,8 @@ resource "aws_iam_role_policy" "github_actions_lambda" {
 
 # Get current AWS account ID
 data "aws_caller_identity" "current" {}
+
+# Reference the GitHub Actions role created in setup
+data "aws_iam_role" "github_actions" {
+  name = "github-actions-ncsh"
+}

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -1,0 +1,153 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# S3 Bucket for Terraform State
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "ncsh-terraform-state"
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# DynamoDB Table for Terraform State Locking
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name           = "ncsh-terraform-state-lock"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "Terraform State Lock Table"
+    Description = "DynamoDB table for Terraform state locking"
+  }
+}
+
+# GitHub Actions OIDC Provider
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ]
+}
+
+# Base IAM Role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name = "github-actions-ncsh"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub": "repo:mzakany23/ncsh:*"
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Base S3 permissions for GitHub Actions
+resource "aws_iam_role_policy" "github_actions_s3" {
+  name = "github-actions-s3-policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketPolicy",
+          "s3:PutBucketPolicy",
+          "s3:GetBucketVersioning",
+          "s3:GetBucketAcl",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetBucketPublicAccessBlock",
+          "s3:PutBucketPublicAccessBlock",
+          "s3:GetBucketLogging",
+          "s3:GetBucketTagging",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          aws_s3_bucket.terraform_state.arn
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetObjectVersion",
+          "s3:GetObjectAcl",
+          "s3:PutObjectAcl"
+        ]
+        Resource = [
+          "${aws_s3_bucket.terraform_state.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+# DynamoDB permissions for GitHub Actions
+resource "aws_iam_role_policy" "github_actions_dynamodb" {
+  name = "github-actions-dynamodb-policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem"
+        ]
+        Resource = [aws_dynamodb_table.terraform_state_lock.arn]
+      }
+    ]
+  })
+}

--- a/terraform/setup/outputs.tf
+++ b/terraform/setup/outputs.tf
@@ -1,0 +1,19 @@
+output "terraform_state_bucket" {
+  description = "Name of the Terraform state bucket"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "terraform_state_lock_table" {
+  description = "Name of the DynamoDB state lock table"
+  value       = aws_dynamodb_table.terraform_state_lock.id
+}
+
+output "github_actions_role_arn" {
+  description = "ARN of the GitHub Actions role"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "github_actions_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}

--- a/terraform/setup/variables.tf
+++ b/terraform/setup/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-2"
+}


### PR DESCRIPTION
## Changes\n\n- Created new setup module for manually applying bootstrap resources:\n  - S3 bucket for Terraform state\n  - DynamoDB table for state locking\n  - GitHub Actions OIDC provider and IAM role\n  - Base IAM policies for S3 and DynamoDB access\n\n- Updated README with manual setup instructions\n- Removed bootstrap resources from infrastructure module\n- Added data source to reference GitHub Actions role\n\n## Manual Steps Required\n1. Apply setup module first:\n   ```bash\n   export AWS_PROFILE=<your-profile-name>\n   cd terraform/setup\n   terraform init\n   terraform apply\n   ```\n2. Use the output `github_actions_role_arn` as AWS_ROLE_ARN in GitHub secrets\n3. After setup is complete, infrastructure module can be applied through GitHub Actions\n\n## Testing\n- [x] Setup module applied successfully\n- [x] S3 bucket and DynamoDB table created\n- [x] GitHub Actions role has correct permissions\n- [x] Infrastructure module references setup resources correctly