### PR TITLE
feat: add setup module with CORS permissions

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -174,7 +174,7 @@ resource "aws_iam_role_policy" "github_actions_s3" {
 # ECR permissions for GitHub Actions
 resource "aws_iam_role_policy" "github_actions_ecr" {
   name = "github-actions-ecr-policy"
-  role = aws_iam_role.github_actions.id
+  role = data.aws_iam_role.github_actions.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -211,7 +211,7 @@ resource "aws_iam_role_policy" "github_actions_ecr" {
 # Lambda permissions for GitHub Actions
 resource "aws_iam_role_policy" "github_actions_lambda" {
   name = "github-actions-lambda-policy"
-  role = aws_iam_role.github_actions.id
+  role = data.aws_iam_role.github_actions.id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -107,7 +107,9 @@ resource "aws_iam_role_policy" "github_actions_s3" {
           "s3:PutBucketPublicAccessBlock",
           "s3:GetBucketLogging",
           "s3:GetBucketTagging",
-          "s3:GetBucketLocation"
+          "s3:GetBucketLocation",
+          "s3:GetBucketCors",
+          "s3:PutBucketCors"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn


### PR DESCRIPTION
## Changes\n\n- Created new setup module for manually applying bootstrap resources:\n  - S3 bucket for Terraform state\n  - DynamoDB table for state locking\n  - GitHub Actions OIDC provider and IAM role\n  - Base IAM policies for S3 (including CORS) and DynamoDB access\n\n- Updated infrastructure module to reference setup resources\n- Added data source to reference GitHub Actions role\n\n## Manual Steps Required\n1. Apply setup module first:\n   ```bash\n   export AWS_PROFILE=<your-profile-name>\n   cd terraform/setup\n   terraform init\n   terraform apply\n   ```\n2. Use the output `github_actions_role_arn` as AWS_ROLE_ARN in GitHub secrets\n3. After setup is complete, infrastructure module can be applied through GitHub Actions\n\n## Testing\n- [x] Setup module applied successfully\n- [x] S3 bucket and DynamoDB table created\n- [x] GitHub Actions role has correct permissions (including CORS)\n- [x] Infrastructure module references setup resources correctly