### PR TITLE
fix: add S3 website permissions to GitHub Actions role

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -109,7 +109,9 @@ resource "aws_iam_role_policy" "github_actions_s3" {
           "s3:GetBucketTagging",
           "s3:GetBucketLocation",
           "s3:GetBucketCors",
-          "s3:PutBucketCors"
+          "s3:PutBucketCors",
+          "s3:GetBucketWebsite",
+          "s3:PutBucketWebsite"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn


### PR DESCRIPTION
## Changes\n\n- Added S3 website-related permissions to GitHub Actions role:\n  - s3:GetBucketWebsite\n  - s3:PutBucketWebsite\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has correct website permissions