### PR TITLE
fix: add comprehensive S3 bucket configuration permissions

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -111,7 +111,15 @@ resource "aws_iam_role_policy" "github_actions_s3" {
           "s3:GetBucketCors",
           "s3:PutBucketCors",
           "s3:GetBucketWebsite",
-          "s3:PutBucketWebsite"
+          "s3:PutBucketWebsite",
+          "s3:GetAccelerateConfiguration",
+          "s3:PutAccelerateConfiguration",
+          "s3:GetBucketRequestPayment",
+          "s3:GetBucketOwnershipControls",
+          "s3:GetBucketNotification",
+          "s3:GetBucketLifecycle",
+          "s3:GetBucketReplication",
+          "s3:GetBucketObjectLockConfiguration"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn


### PR DESCRIPTION
## Changes\n\nAdded comprehensive S3 bucket configuration permissions to avoid permission issues:\n- s3:GetAccelerateConfiguration\n- s3:PutAccelerateConfiguration\n- s3:GetBucketRequestPayment\n- s3:GetBucketOwnershipControls\n- s3:GetBucketNotification\n- s3:GetBucketLifecycle\n- s3:GetBucketReplication\n- s3:GetBucketObjectLockConfiguration\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has all necessary S3 bucket configuration permissions