### PR TITLE
fix: add comprehensive S3 bucket configuration permissions

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -119,7 +119,9 @@ resource "aws_iam_role_policy" "github_actions_s3" {
           "s3:GetBucketNotification",
           "s3:GetBucketLifecycle",
           "s3:GetBucketReplication",
-          "s3:GetBucketObjectLockConfiguration"
+          "s3:GetBucketObjectLockConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:PutLifecycleConfiguration"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn


### PR DESCRIPTION
## Changes\n\nAdded comprehensive S3 bucket configuration permissions to avoid permission issues:\n- s3:GetAccelerateConfiguration\n- s3:PutAccelerateConfiguration\n- s3:GetBucketRequestPayment\n- s3:GetBucketOwnershipControls\n- s3:GetBucketNotification\n- s3:GetBucketLifecycle\n- s3:GetBucketReplication\n- s3:GetBucketObjectLockConfiguration\n- s3:GetLifecycleConfiguration\n- s3:PutLifecycleConfiguration\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has all necessary S3 bucket configuration permissions