### PR TITLE
fix: add S3 replication configuration permissions

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -121,7 +121,9 @@ resource "aws_iam_role_policy" "github_actions_s3" {
           "s3:GetBucketReplication",
           "s3:GetBucketObjectLockConfiguration",
           "s3:GetLifecycleConfiguration",
-          "s3:PutLifecycleConfiguration"
+          "s3:PutLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:PutReplicationConfiguration"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn


### PR DESCRIPTION
## Changes\n\nAdded S3 replication configuration permissions to GitHub Actions role:\n- s3:GetReplicationConfiguration\n- s3:PutReplicationConfiguration\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has necessary replication configuration permissions