### PR TITLE
fix: add comprehensive DynamoDB permissions for Terraform state management

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -161,7 +161,11 @@ resource "aws_iam_role_policy" "github_actions_dynamodb" {
           "dynamodb:GetItem",
           "dynamodb:PutItem",
           "dynamodb:DeleteItem",
-          "dynamodb:DescribeTable"
+          "dynamodb:DescribeTable",
+          "dynamodb:DescribeContinuousBackups",
+          "dynamodb:DescribeTimeToLive",
+          "dynamodb:ListTagsOfResource",
+          "dynamodb:DescribeTableReplicaAutoScaling"
         ]
         Resource = [aws_dynamodb_table.terraform_state_lock.arn]
       }


### PR DESCRIPTION
## Changes\n\nAdded comprehensive DynamoDB permissions to GitHub Actions role to handle all aspects of Terraform state management. This includes:\n\n- dynamodb:DescribeContinuousBackups\n- dynamodb:DescribeTimeToLive\n- dynamodb:ListTagsOfResource\n- dynamodb:DescribeTableReplicaAutoScaling\n\n## Why These Permissions?\n\nTerraform needs these permissions because it validates all aspects of the DynamoDB table during its operations, even if we're not explicitly configuring these features. This comprehensive set should prevent future permission errors when Terraform checks table attributes.\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has all necessary DynamoDB permissions for state management