### PR TITLE
fix: add comprehensive ECR permissions for GitHub Actions

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -172,3 +172,40 @@ resource "aws_iam_role_policy" "github_actions_dynamodb" {
     ]
   })
 }
+
+# ECR permissions for GitHub Actions
+resource "aws_iam_role_policy" "github_actions_ecr" {
+  name = "github-actions-ecr-policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart",
+          "ecr:DescribeImages",
+          "ecr:ListImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetRepositoryPolicy",
+          "ecr:ListTagsForResource",
+          "ecr:GetLifecyclePolicy",
+          "ecr:GetLifecyclePolicyPreview",
+          "ecr:CreateRepository",
+          "ecr:DeleteRepository",
+          "ecr:TagResource",
+          "ecr:UntagResource"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## Changes\n\nAdded comprehensive ECR permissions to GitHub Actions role. This includes all necessary permissions for managing ECR repositories and images:\n\n### Repository Management\n- ecr:ListTagsForResource\n- ecr:DescribeRepositories\n- ecr:GetRepositoryPolicy\n- ecr:CreateRepository\n- ecr:DeleteRepository\n- ecr:TagResource\n- ecr:UntagResource\n\n### Image Management\n- ecr:GetAuthorizationToken\n- ecr:BatchGetImage\n- ecr:BatchCheckLayerAvailability\n- ecr:CompleteLayerUpload\n- ecr:GetDownloadUrlForLayer\n- ecr:InitiateLayerUpload\n- ecr:PutImage\n- ecr:UploadLayerPart\n- ecr:DescribeImages\n- ecr:ListImages\n\n### Lifecycle Management\n- ecr:GetLifecyclePolicy\n- ecr:GetLifecyclePolicyPreview\n\n## Why These Permissions?\n\nTerraform needs these permissions to manage ECR repositories and validate their state. This includes:\n- Reading and managing repository tags\n- Managing images and layers\n- Checking lifecycle policies\n- Basic repository operations\n\nThis comprehensive set should prevent future permission errors when Terraform manages ECR resources.\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has all necessary ECR permissions