### PR TITLE
fix: add comprehensive IAM permissions for OIDC and role management

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -209,3 +209,46 @@ resource "aws_iam_role_policy" "github_actions_ecr" {
     ]
   })
 }
+
+# IAM permissions for GitHub Actions
+resource "aws_iam_role_policy" "github_actions_iam" {
+  name = "github-actions-iam-policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:GetOpenIDConnectProvider",
+          "iam:CreateOpenIDConnectProvider",
+          "iam:DeleteOpenIDConnectProvider",
+          "iam:UpdateOpenIDConnectProviderThumbprint",
+          "iam:AddClientIDToOpenIDConnectProvider",
+          "iam:RemoveClientIDFromOpenIDConnectProvider",
+          "iam:ListOpenIDConnectProviders",
+          "iam:ListOpenIDConnectProviderTags",
+          "iam:TagOpenIDConnectProvider",
+          "iam:UntagOpenIDConnectProvider",
+          "iam:GetRole",
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:UpdateRole",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:GetRolePolicy"
+        ]
+        Resource = [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com",
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
+        ]
+      }
+    ]
+  })
+}
+
+# Get current AWS account ID
+data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## Changes\n\nAdded comprehensive IAM permissions to GitHub Actions role for managing OIDC providers and IAM roles. This includes:\n\n### OIDC Provider Management\n- iam:GetOpenIDConnectProvider\n- iam:CreateOpenIDConnectProvider\n- iam:DeleteOpenIDConnectProvider\n- iam:UpdateOpenIDConnectProviderThumbprint\n- iam:AddClientIDToOpenIDConnectProvider\n- iam:RemoveClientIDFromOpenIDConnectProvider\n- iam:ListOpenIDConnectProviders\n- iam:ListOpenIDConnectProviderTags\n- iam:TagOpenIDConnectProvider\n- iam:UntagOpenIDConnectProvider\n\n### Role Management\n- iam:GetRole\n- iam:CreateRole\n- iam:DeleteRole\n- iam:UpdateRole\n- iam:ListRolePolicies\n- iam:ListAttachedRolePolicies\n- iam:PutRolePolicy\n- iam:DeleteRolePolicy\n- iam:GetRolePolicy\n\n## Why These Permissions?\n\nTerraform needs these permissions to manage and validate IAM resources, specifically:\n- Reading and managing OIDC provider configurations\n- Managing IAM roles and their policies\n- Handling role-policy attachments\n\nThis comprehensive set should prevent future permission errors when Terraform manages IAM resources.\n\n## Testing\n- [x] Applied changes locally\n- [x] GitHub Actions role has all necessary IAM permissions