### PR TITLE
fix: update infrastructure outputs to match actual resources

### DIFF
--- a/terraform/infrastructure/outputs.tf
+++ b/terraform/infrastructure/outputs.tf
@@ -1,23 +1,10 @@
-output "terraform_state_bucket" {
-  description = "Name of the Terraform state bucket"
-  value       = aws_s3_bucket.terraform_state.id
-}
-
+# Output the app data bucket name
 output "app_data_bucket" {
   description = "Name of the application data bucket"
   value       = aws_s3_bucket.app_data.id
 }
 
-output "github_actions_role_arn" {
-  description = "ARN of the base GitHub Actions role"
-  value       = aws_iam_role.github_actions.arn
-}
-
-output "github_actions_oidc_provider_arn" {
-  description = "ARN of the GitHub Actions OIDC provider"
-  value       = aws_iam_openid_connect_provider.github_actions.arn
-}
-
+# Output the ECR repository details
 output "ecr_repository_url" {
   description = "URL of the ECR repository"
   value       = aws_ecr_repository.ncsoccer.repository_url


### PR DESCRIPTION
## Changes Made\n\nUpdated the infrastructure module outputs to only include resources that are actually defined in the module:\n\n- Removed references to terraform state bucket (moved to setup)\n- Removed references to GitHub Actions role (moved to setup)\n- Kept only app data bucket and ECR repository outputs\n\n## Why These Changes?\nThis aligns the outputs with the actual resources managed in the infrastructure module after the cleanup.