### PR TITLE
fix: add s3:HeadBucket permission to GitHub Actions role

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -128,7 +128,8 @@ resource "aws_iam_role_policy" "github_actions_s3" {
           "s3:PutBucketEncryption",
           "s3:PutEncryptionConfiguration",
           "s3:PutBucketOwnershipControls",
-          "s3:PutBucketTagging"
+          "s3:PutBucketTagging",
+          "s3:HeadBucket"
         ]
         Resource = [
           aws_s3_bucket.terraform_state.arn,


### PR DESCRIPTION
## Changes Made\n\nAdded the `s3:HeadBucket` permission to the GitHub Actions role in the setup module.\n\n## Why This Change?\nThe GitHub Actions role needs this permission to check if S3 buckets exist during Terraform operations. This fixes the 403 Forbidden error when trying to check the app data bucket's existence.\n\n## Testing\n- [ ] Apply setup module changes\n- [ ] Verify infrastructure module can check bucket existence