### PR TITLE
refactor: reorganize infrastructure and simplify build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,39 +92,3 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: "1.5.0"
-
-    - name: Terraform Init (App)
-      working-directory: ./terraform/app
-      run: |
-        terraform init \
-          -backend-config="bucket=${{ env.TF_STATE_BUCKET }}" \
-          -backend-config="key=app/terraform.tfstate" \
-          -backend-config="region=${{ env.AWS_REGION }}"
-      env:
-        TF_VAR_aws_region: ${{ env.AWS_REGION }}
-
-    - name: Terraform Plan (App)
-      working-directory: ./terraform/app
-      run: terraform plan -input=false -out=tfplan
-      env:
-        TF_VAR_aws_region: ${{ env.AWS_REGION }}
-        TF_VAR_github_repo: ${{ github.repository }}
-        TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
-        TF_VAR_tf_state_bucket: ${{ env.TF_STATE_BUCKET }}
-        TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}
-
-    - name: Terraform Apply (App)
-      if: github.ref == 'refs/heads/main'
-      working-directory: ./terraform/app
-      run: terraform apply -auto-approve tfplan
-      env:
-        TF_VAR_aws_region: ${{ env.AWS_REGION }}
-        TF_VAR_github_repo: ${{ github.repository }}
-        TF_VAR_ecr_repository_name: ${{ env.ECR_REPOSITORY }}
-        TF_VAR_tf_state_bucket: ${{ env.TF_STATE_BUCKET }}
-        TF_VAR_data_bucket_name: ${{ secrets.DATA_BUCKET_NAME }}

--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -49,5 +49,216 @@ resource "aws_ecr_repository" "ncsoccer" {
   }
 }
 
+# IAM Role for Lambda
+resource "aws_iam_role" "lambda_role" {
+  name = "ncsoccer_lambda_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# IAM Policy for Lambda
+resource "aws_iam_role_policy" "lambda_policy" {
+  name = "ncsoccer_lambda_policy"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:GetObjectVersion",
+          "s3:PutObjectAcl",
+          "s3:GetObjectAcl"
+        ]
+        Resource = [
+          aws_s3_bucket.app_data.arn,
+          "${aws_s3_bucket.app_data.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+# Lambda Function
+resource "aws_lambda_function" "ncsoccer_scraper" {
+  function_name = "ncsoccer_scraper"
+  role          = aws_iam_role.lambda_role.arn
+  timeout       = 300 # 5 minutes
+  memory_size   = 512
+
+  package_type = "Image"
+  image_uri    = "${aws_ecr_repository.ncsoccer.repository_url}:latest"
+
+  environment {
+    variables = {
+      DATA_BUCKET = aws_s3_bucket.app_data.id
+    }
+  }
+}
+
+# IAM Role for Step Function
+resource "aws_iam_role" "step_function_role" {
+  name = "ncsoccer_step_function_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "states.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# IAM Policy for Step Function
+resource "aws_iam_role_policy" "step_function_policy" {
+  name = "ncsoccer_step_function_policy"
+  role = aws_iam_role.step_function_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction"
+        ]
+        Resource = [
+          aws_lambda_function.ncsoccer_scraper.arn
+        ]
+      }
+    ]
+  })
+}
+
+# Step Function Definition
+resource "aws_sfn_state_machine" "ncsoccer_workflow" {
+  name     = "ncsoccer-workflow"
+  role_arn = aws_iam_role.step_function_role.arn
+
+  definition = jsonencode({
+    Comment = "NC Soccer Scraper Workflow"
+    StartAt = "ScrapeSchedule"
+    States = {
+      ScrapeSchedule = {
+        Type = "Task"
+        Resource = aws_lambda_function.ncsoccer_scraper.arn
+        Retry = [
+          {
+            ErrorEquals = ["States.TaskFailed"]
+            IntervalSeconds = 30
+            MaxAttempts = 3
+            BackoffRate = 2.0
+          }
+        ]
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            Next = "HandleError"
+          }
+        ]
+        End = true
+      }
+      HandleError = {
+        Type = "Pass"
+        Result = {
+          error = "Failed to scrape schedule"
+          status = "FAILED"
+        }
+        End = true
+      }
+    }
+  })
+}
+
+# EventBridge rule to trigger Step Function monthly
+resource "aws_cloudwatch_event_rule" "monthly_schedule" {
+  name                = "ncsoccer-monthly-schedule"
+  description         = "Trigger NC Soccer scraper workflow monthly"
+  schedule_expression = "cron(0 0 1 * ? *)" # Run at midnight on the first day of every month
+  state              = "ENABLED"
+}
+
+# EventBridge target for Step Function
+resource "aws_cloudwatch_event_target" "step_function" {
+  rule      = aws_cloudwatch_event_rule.monthly_schedule.name
+  target_id = "NCSoccerStepFunction"
+  arn       = aws_sfn_state_machine.ncsoccer_workflow.arn
+  role_arn  = aws_iam_role.eventbridge_role.arn
+
+  input = jsonencode({
+    year  = "$${time:getYear}"
+    month = "$${time:getMonth}"
+    mode  = "month"
+  })
+}
+
+# IAM Role for EventBridge
+resource "aws_iam_role" "eventbridge_role" {
+  name = "ncsoccer_eventbridge_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# IAM Policy for EventBridge
+resource "aws_iam_role_policy" "eventbridge_policy" {
+  name = "ncsoccer_eventbridge_policy"
+  role = aws_iam_role.eventbridge_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "states:StartExecution"
+        ]
+        Resource = [
+          aws_sfn_state_machine.ncsoccer_workflow.arn
+        ]
+      }
+    ]
+  })
+}
+
 # Get current AWS account ID
 data "aws_caller_identity" "current" {}

--- a/terraform/infrastructure/outputs.tf
+++ b/terraform/infrastructure/outputs.tf
@@ -14,3 +14,13 @@ output "ecr_repository_name" {
   description = "Name of the ECR repository"
   value       = aws_ecr_repository.ncsoccer.name
 }
+
+output "lambda_function_name" {
+  description = "Name of the Lambda function"
+  value       = aws_lambda_function.ncsoccer_scraper.function_name
+}
+
+output "step_function_arn" {
+  description = "ARN of the Step Function state machine"
+  value       = aws_sfn_state_machine.ncsoccer_workflow.arn
+}


### PR DESCRIPTION
## Changes Made\n\n1. Infrastructure Module Changes:\n- Moved all application infrastructure from app module to infrastructure module\n- Added Lambda function and IAM role/policy\n- Added Step Function and IAM role/policy\n- Added EventBridge rule and target with IAM role/policy\n- Kept existing ECR repository and app data bucket\n\n2. GitHub Actions Changes:\n- Simplified build-service job to only handle Docker build/push\n- Removed app module Terraform steps\n\n## Testing\n- [x] Setup module plan shows no changes\n- [x] Infrastructure module plan shows correct resource creation\n- [x] No disruption to existing resources (ECR, S3)\n\n## Why These Changes?\nThis reorganization provides a cleaner separation of concerns:\n- Setup module: Foundational resources (state, OIDC)\n- Infrastructure module: ALL application infrastructure\n- Build workflow: Only container builds