### PR TITLE
feat: add ECR repository policy permissions to GitHub Actions role

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -203,7 +203,10 @@ resource "aws_iam_role_policy" "github_actions_ecr" {
           "ecr:UploadLayerPart",
           "ecr:CompleteLayerUpload",
           "ecr:PutImage",
-          "ecr:ListTagsForResource"
+          "ecr:ListTagsForResource",
+          "ecr:SetRepositoryPolicy",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DeleteRepositoryPolicy"
         ]
         Resource = ["arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/ncsoccer-scraper"]
       },


### PR DESCRIPTION
This PR adds necessary ECR repository policy permissions to the GitHub Actions role to allow managing ECR repository policies.