### PR TITLE
Add missing IAM permissions for ECR lifecycle and AWS Budgets

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -206,7 +206,10 @@ resource "aws_iam_role_policy" "github_actions_ecr" {
           "ecr:ListTagsForResource",
           "ecr:SetRepositoryPolicy",
           "ecr:GetRepositoryPolicy",
-          "ecr:DeleteRepositoryPolicy"
+          "ecr:DeleteRepositoryPolicy",
+          "ecr:PutLifecyclePolicy",
+          "ecr:GetLifecyclePolicy",
+          "ecr:DeleteLifecyclePolicy"
         ]
         Resource = ["arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/ncsoccer-scraper"]
       },
@@ -216,6 +219,29 @@ resource "aws_iam_role_policy" "github_actions_ecr" {
           "ecr:GetAuthorizationToken"
         ]
         Resource = ["*"]
+      }
+    ]
+  })
+}
+
+# AWS Budgets permissions for GitHub Actions
+resource "aws_iam_role_policy" "github_actions_budgets" {
+  name = "github-actions-budgets-policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "budgets:ModifyBudget",
+          "budgets:CreateBudget",
+          "budgets:DeleteBudget",
+          "budgets:DescribeBudget",
+          "budgets:ViewBudget"
+        ]
+        Resource = ["arn:aws:budgets::${data.aws_caller_identity.current.account_id}:budget/*"]
       }
     ]
   })


### PR DESCRIPTION
## Changes\n\nAdd missing IAM permissions to fix deployment issues:\n\n1. ECR Lifecycle Policy:\n   - Add ecr:PutLifecyclePolicy\n   - Add ecr:GetLifecyclePolicy\n   - Add ecr:DeleteLifecyclePolicy\n\n2. AWS Budgets:\n   - Add new dedicated policy for Budgets management\n   - Include all necessary budgets:* permissions\n\n## Approach\n- Group related permissions in dedicated policies\n- Include comprehensive permissions upfront\n- Properly scope resource ARNs\n\nThis should resolve the current deployment errors related to ECR lifecycle policies and AWS Budgets creation.