### PR TITLE
Add security condition to ECR policy and trigger pipeline

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  # Trigger pipeline to test updated IAM permissions (ECR lifecycle and AWS Budgets)
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -108,6 +109,11 @@ resource "aws_ecr_repository_policy" "ncsoccer_policy" {
           "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability"
         ]
+        Condition = {
+          StringLike = {
+            "aws:SourceArn": "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:ncsoccer_scraper"
+          }
+        }
       }
     ]
   })


### PR DESCRIPTION
## Changes\n\n1. Add security condition to ECR repository policy:\n   - Restrict access to specific Lambda function using aws:SourceArn condition\n   - Improves security by preventing unauthorized Lambda functions from accessing the ECR repository\n\n2. Trigger pipeline to test:\n   - Updated IAM permissions for ECR lifecycle and AWS Budgets\n   - ECR security condition