### PR TITLE
Add back lambda:ListVersionsByFunction permission

### DIFF
--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -282,7 +282,8 @@ resource "aws_iam_role_policy" "github_actions_iam" {
           "lambda:GetFunction",
           "lambda:DeleteFunction",
           "lambda:UpdateFunctionCode",
-          "lambda:UpdateFunctionConfiguration"
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:ListVersionsByFunction"
         ]
         Resource = [
           "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com",


### PR DESCRIPTION
## Fix Regression\n\nAdd back lambda:ListVersionsByFunction permission to GitHub Actions IAM policy that was accidentally removed in a previous change.\n\n## Impact\n- Fixes deployment error where GitHub Actions couldn't list Lambda function versions\n- Required for proper Lambda function management\n\n## Testing\n- [ ] Apply setup changes first\n- [ ] Verify infrastructure deployment succeeds