### PR TITLE
feat: Update IAM permissions for Terraform state lock

### DIFF
--- a/terraform/setup/variables.tf
+++ b/terraform/setup/variables.tf
@@ -3,3 +3,8 @@ variable "aws_region" {
   type        = string
   default     = "us-east-2"
 }
+
+variable "alert_email" {
+  description = "Email address to receive budget alerts"
+  type        = string
+}


### PR DESCRIPTION
This PR updates the IAM permissions to resolve issues with Terraform state locking in GitHub Actions. Changes: - Updated IAM permissions for GitHub Actions role - Added necessary permissions for Terraform state management - Configured proper access for DynamoDB state locking