### PR TITLE
feat: use SHA-tagged images and virtual env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 # Base image for NC Soccer Scraper Lambda function
 # Handles both day and month mode scraping operations
-# Rebuilding to ensure latest code changes are included
+# Using SHA-tagged images for versioning
 FROM public.ecr.aws/lambda/python:3.11
+
+# Create and activate virtual environment
+RUN python -m venv ${LAMBDA_TASK_ROOT}/.venv
+ENV PATH="${LAMBDA_TASK_ROOT}/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV="${LAMBDA_TASK_ROOT}/.venv"
+
+# Add build argument to force fresh pip installs
+ARG BUILD_DATE=unknown
 
 # Copy requirements.txt
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 
-# Install the specified packages
+# Install the specified packages in the virtual environment
 RUN pip install -r requirements.txt
 
 # Copy function code


### PR DESCRIPTION
- Updates workflow to use SHA-tagged images instead of latest\n- Updates Lambda to use specific SHA-tagged images\n- Adds virtual environment to Dockerfile\n- Ensures each deployment uses the exact intended image version