### PR TITLE
fix: update Lambda handler name to match function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Updated Lambda handler name in Dockerfile to match function name in lambda_function.py
+
 ## [1.2.0] - 2024-03-16
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ COPY scrapy.cfg ${LAMBDA_TASK_ROOT}
 # Copy lambda handler
 COPY lambda_function.py ${LAMBDA_TASK_ROOT}
 
-# Set the CMD to your handler
-CMD [ "lambda_function.handler" ]
+# Set the CMD to your handler (matches the function name in lambda_function.py)
+CMD [ "lambda_function.lambda_handler" ]


### PR DESCRIPTION
## Description\nFixed the Lambda handler name in Dockerfile to match the actual function name in lambda_function.py (lambda_handler).\n\n## Changes\n- Updated CMD in Dockerfile from 'lambda_function.handler' to 'lambda_function.lambda_handler'\n- Added clarifying comment in Dockerfile\n- Added entry to CHANGELOG.md under Unreleased section\n\n## Testing\nThe CI pipeline will:\n1. Build the Docker image\n2. Push to ECR\n3. Update the Lambda function\n\nThis should resolve the Runtime.HandlerNotFound error we're seeing in production.