### PR TITLE
fix: remove test prefixes and reduce log noise

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -7,6 +7,12 @@ from runner import run_scraper, run_month
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+# Suppress DEBUG messages from third-party libraries
+logging.getLogger("twisted").setLevel(logging.WARNING)
+logging.getLogger("scrapy").setLevel(logging.WARNING)
+logging.getLogger("botocore").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("boto3").setLevel(logging.WARNING)
 
 def lambda_handler(event, context):
     """AWS Lambda handler function"""
@@ -40,8 +46,8 @@ def lambda_handler(event, context):
                 month=month,
                 storage_type='s3',
                 bucket_name=bucket_name,
-                html_prefix='test_data/html',  # Use test_data prefix
-                json_prefix='test_data/json',  # Use test_data prefix
+                html_prefix='data/html',  # Use production prefix
+                json_prefix='data/json',  # Use production prefix
                 lookup_type='dynamodb',  # Use DynamoDB lookup in Lambda
                 region='us-east-2'
             )


### PR DESCRIPTION
This PR:\n1. Removes test prefixes from run_month function in Lambda handler\n2. Reduces log noise by setting third-party libraries to WARNING level\n\nThis fixes the issue where the Lambda function was looking for files in test_data/ instead of data/ and cleans up the CloudWatch logs.