### PR TITLE
fix: disable Scrapy telnet console for Lambda

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -124,7 +124,8 @@ def run_month(year=None, month=None, storage_type='s3', bucket_name=None,
             'LOG_LEVEL': 'INFO',
             'COOKIES_DEBUG': True,
             'DOWNLOAD_DELAY': 1,
-            'CONCURRENT_REQUESTS': 1
+            'CONCURRENT_REQUESTS': 1,
+            'TELNETCONSOLE_ENABLED': False  # Disable telnet console for Lambda
         })
         process = CrawlerProcess(settings)
 


### PR DESCRIPTION
This PR:\n1. Disables Scrapy's telnet console in Lambda\n2. Fixes the 'Address already in use' error in Lambda\n\nThe telnet console was trying to bind to a port, which isn't allowed in Lambda. This change disables that feature since we don't need it in Lambda anyway.