### PR TITLE
fix: remove pull_request trigger from github actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,16 +12,6 @@ on:
       - 'lambda_function.py'
       - 'runner.py'
       - 'CHANGELOG.md'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'ncsoccer/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - '.github/workflows/deploy.yml'
-      - 'lambda_function.py'
-      - 'runner.py'
-      - 'CHANGELOG.md'
 
 env:
   AWS_REGION: us-east-2


### PR DESCRIPTION
- Removed pull_request trigger from GitHub Actions workflow\n- Now only deploys on pushes to main (including merges) and manual workflow dispatch\n- Prevents duplicate deployments from feature branches