### PR TITLE
fix: update deployment workflow to only trigger on merged PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Build and Deploy
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [closed]
     branches: [ main ]
     paths:
       - 'CHANGELOG.md'
@@ -15,6 +16,7 @@ env:
 
 jobs:
   validate-changes:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed scraping module imports by moving runner.py into package
 - Updated tests to use correct module paths
 - Fixed Lambda function imports to use proper package structure
+- Fixed deployment workflow to only trigger on merged PRs to main
 
 ## [2.0.1] - 2025-02-16
 ### Fixed


### PR DESCRIPTION
## Changes\n\n- Changed deployment workflow trigger from push to pull_request with type closed\n- Added condition to only run on merged PRs to main\n- Maintains CHANGELOG.md path filter for version control\n- Keeps workflow_dispatch for manual triggers\n\nThis ensures builds only happen when:\n1. A PR is merged to main (not just pushed)\n2. The PR includes changes to CHANGELOG.md\n3. Or when manually triggered via workflow_dispatch