### PR TITLE
fix: include pull_request events in build conditions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
     paths:
       - 'CHANGELOG.md'
+  push:
+    branches: [main]
+    paths:
+      - 'CHANGELOG.md'
 env:
   AWS_REGION: us-east-2
   SCRAPER_REPOSITORY: ncsoccer-scraper
@@ -47,8 +51,8 @@ jobs:
 
   build-scraper:
     needs: [validate-changes]
-    # Only build on main branch push or manual trigger
-    if: (needs.validate-changes.outputs.should_run == 'true' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
+    # Build on main branch push, pull request, or manual trigger
+    if: (needs.validate-changes.outputs.should_run == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: dev
     permissions:
@@ -87,8 +91,8 @@ jobs:
 
   build-processing:
     needs: [validate-changes]
-    # Only build on main branch push or manual trigger
-    if: (needs.validate-changes.outputs.should_run == 'true' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
+    # Build on main branch push, pull request, or manual trigger
+    if: (needs.validate-changes.outputs.should_run == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: dev
     permissions:


### PR DESCRIPTION
## Changes\n\n- Updated build job conditions to run on pull_request events\n- Both build-scraper and build-processing jobs will now run when:\n  1. A valid CHANGELOG update is detected AND (it's a push OR pull_request event)\n  2. OR when manually triggered via workflow_dispatch\n\nThis ensures builds run during PR validation while maintaining the CHANGELOG requirement.