### PR TITLE
fix: Add parameter preservation for backfill workflow in unified Step Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.6] - 2025-03-19
+### Fixed
+- Fixed backfill operation in unified workflow by adding parameter preservation between states
+- Added PreserveParametersAfterBackfill state to maintain context for subsequent Lambda invocations
+- Ensured consistent parameter handling across all operation modes (daily, monthly, backfill, configurable)
+
 ## [2.10.5] - 2025-03-19
 ### Fixed
 - Fixed timestamp handling in build_dataset function when creating final Parquet files

--- a/terraform/infrastructure/unified-workflow-updated.asl.json
+++ b/terraform/infrastructure/unified-workflow-updated.asl.json
@@ -186,6 +186,21 @@
           "Next": "HandleBackfillFailure"
         }
       ],
+      "ResultPath": "$.backfill_result",
+      "Next": "PreserveParametersAfterBackfill"
+    },
+
+    "PreserveParametersAfterBackfill": {
+      "Type": "Pass",
+      "Parameters": {
+        "backfill_result.$": "$.backfill_result",
+        "src_bucket.$": "$.src_bucket",
+        "src_prefix.$": "$.src_prefix",
+        "dst_bucket.$": "$.dst_bucket",
+        "dst_prefix.$": "$.dst_prefix",
+        "version.$": "$.version",
+        "force_full_reprocess.$": "$.force_full_reprocess"
+      },
       "Next": "ListJSONFiles"
     },
 


### PR DESCRIPTION
This PR fixes the backfill operation in the unified Step Function workflow by adding a parameter preservation state. The issue was that after the backfill Lambda executed, the source/destination bucket parameters were lost, causing the ListJSONFiles state to fail. Added a new PreserveParametersAfterBackfill state similar to the existing PreserveParametersAfterScraper state used in the other workflow paths.