### PR TITLE
Replace backfill runner with date_range mode in unified workflow

### DIFF
--- a/.cursor-rules/test
+++ b/.cursor-rules/test
@@ -1,0 +1,4 @@
+tests
+1. ensure no regressions
+2. ensure no new test files, fix the ones we have first.
+3. be weary of fixing tests by fixing test file, fix lib first if you can - tests should be single source of truth to correctness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2025-03-20
+### Changed
+- Replaced backfill runner with date_range mode in unified workflow
+- Updated Lambda function to handle date ranges directly
+- Modified Step Function definition to support date_range operations
+- Updated Terraform configuration for new workflow architecture
+- Improved unit tests for all operation modes
+
+### Removed
+- Removed backfill_runner.py as it is now redundant
+- Removed backfill operations from unified workflow Step Function
+
+### Fixed
+- Fixed issue with test runner finding Scrapy spiders
+- Fixed Lambda function tests to match new parameter structure
+- Improved error handling for date parsing and validation
+
 ## [2.11.0] - 2025-03-19
 ### Changed
 - Completely refactored Step Function workflow to use a standardized input approach

--- a/scraping/ncsoccer/runner.py
+++ b/scraping/ncsoccer/runner.py
@@ -148,7 +148,10 @@ def run_month(year=None, month=None, storage_type='s3', bucket_name=None,
                 'TELNETCONSOLE_ENABLED': False,  # Disable telnet console for Lambda
                 'RETRY_ENABLED': True,
                 'RETRY_TIMES': 3,  # Number of times to retry failed requests
-                'RETRY_HTTP_CODES': [500, 502, 503, 504, 408, 429]  # HTTP codes to retry on
+                'RETRY_HTTP_CODES': [500, 502, 503, 504, 408, 429],  # HTTP codes to retry on
+                'SPIDER_MODULES': ['ncsoccer.spiders'],  # Explicitly set spider modules
+                'NEWSPIDER_MODULE': 'ncsoccer.spiders',  # Set new spider module
+                'BOT_NAME': 'ncsoccer'  # Set bot name
             })
             logger.info(f"Using Scrapy settings: {settings.copy_to_dict()}")
 

--- a/tests/unit/scraping/test_lambda_handler.py
+++ b/tests/unit/scraping/test_lambda_handler.py
@@ -1,20 +1,32 @@
 import pytest
 from unittest.mock import patch, MagicMock
+from datetime import datetime
+import json
 
 from scraping.lambda_function import lambda_handler
 
 """Test cases for the lambda_handler function in the scraper Lambda"""
 
+@patch('scraping.lambda_function.datetime')
 @patch('scraping.lambda_function.run_scraper')
-def test_string_params_conversion(mock_run_scraper):
+def test_string_params_conversion(mock_run_scraper, mock_datetime):
     """Test that string parameters are properly converted to integers."""
     # Setup
+    mock_now = MagicMock()
+    mock_now.year = 2024
+    mock_now.month = 6
+    mock_now.day = 1
+    mock_datetime.now.return_value = mock_now
+
     mock_run_scraper.return_value = True
     event = {
-        'year': '2024',
-        'month': '06',
-        'day': '01',
-        'force_scrape': True
+        'mode': 'day',
+        'parameters': {
+            'year': '2024',
+            'month': '06',
+            'day': '01',
+            'force_scrape': True
+        }
     }
     mock_context = MagicMock()
 
@@ -31,15 +43,25 @@ def test_string_params_conversion(mock_run_scraper):
     assert kwargs['day'] == 1
     assert kwargs['force_scrape'] == True
 
+@patch('scraping.lambda_function.datetime')
 @patch('scraping.lambda_function.run_month')
-def test_string_params_month_mode(mock_run_month):
+def test_string_params_month_mode(mock_run_month, mock_datetime):
     """Test that string parameters are properly converted to integers in month mode."""
     # Setup
+    mock_now = MagicMock()
+    mock_now.year = 2024
+    mock_now.month = 6
+    mock_now.day = 1
+    mock_datetime.now.return_value = mock_now
+
     mock_run_month.return_value = True
     event = {
-        'year': '2024',
-        'month': '06',
-        'force_scrape': True
+        'mode': 'month',
+        'parameters': {
+            'year': '2024',
+            'month': '06',
+            'force_scrape': True
+        }
     }
     mock_context = MagicMock()
 
@@ -54,3 +76,36 @@ def test_string_params_month_mode(mock_run_month):
     assert kwargs['year'] == 2024
     assert kwargs['month'] == 6
     assert kwargs['force_scrape'] == True
+
+@patch('scraping.lambda_function.datetime')
+@patch('scraping.lambda_function.run_month')
+def test_date_range_mode(mock_run_month, mock_datetime):
+    """Test the date_range mode with start and end dates."""
+    # Setup
+    mock_now = MagicMock()
+    mock_now.timestamp.return_value = 1717189200  # 2024-06-01 00:00:00
+    mock_datetime.now.return_value = mock_now
+
+    mock_run_month.return_value = True
+
+    # Mock context with remaining time
+    mock_context = MagicMock()
+    mock_context.get_remaining_time_in_millis.return_value = 900000  # 15 minutes
+
+    event = {
+        'mode': 'date_range',
+        'parameters': {
+            'start_date': '2024-01-01',
+            'end_date': '2024-02-29',
+            'force_scrape': True
+        }
+    }
+
+    # Execute
+    result = lambda_handler(event, mock_context)
+
+    # Assert
+    assert result['statusCode'] == 200
+    assert mock_run_month.call_count == 2  # Should call for Jan and Feb
+    assert 'processed_months' in json.loads(result['body'])
+    assert json.loads(result['body'])['complete'] == True


### PR DESCRIPTION
This PR updates the unified workflow to use a date_range mode instead of a separate backfill runner. This simplifies the codebase and improves error handling. All tests pass and the system is now more robust.