### PR TITLE
Fix spider name reference in runner.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] - 2025-03-20
+### Fixed
+- Fixed incorrect spider name reference in runner.py from 'schedule_spider' to 'schedule'
+
 ## [2.13.0] - 2025-03-20
 ### Added
 - Implemented v2 data architecture with improved partitioning and organization

--- a/scraping/ncsoccer/runner.py
+++ b/scraping/ncsoccer/runner.py
@@ -269,7 +269,7 @@ def run_month(year=None, month=None, storage_type='s3', bucket_name=None,
                     date_str = f"{year}-{month:02d}-{day:02d}"
 
                     # Configure spider
-                    spider = process.create_crawler('schedule_spider')
+                    spider = process.create_crawler('schedule')
                     d = process.crawl(
                         spider,
                         mode='day',


### PR DESCRIPTION
This PR fixes an incorrect spider name reference in runner.py where it was trying to use 'schedule_spider' instead of 'schedule' when creating the crawler. This aligns with the actual spider name defined in schedule_spider.py and should resolve the 'Spider not found' error in the v2 architecture.