### PR TITLE
Fix NCSoccerSpider reference in runner.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.2] - 2025-03-25
+### Fixed
+- Fixed the runner.py file to use the correct ScheduleSpider class instead of non-existent NCSoccerSpider
+- Updated imports to include the proper class: `from ncsoccer.spiders.schedule_spider import ScheduleSpider`
+- Ensured proper spider class references throughout the runner.py file
+
 ## [2.14.1] - 2025-03-25
 ### Fixed
 - Fixed Step Function input validation to handle default values properly

--- a/scraping/ncsoccer/runner.py
+++ b/scraping/ncsoccer/runner.py
@@ -24,6 +24,8 @@ _reactor_started = False
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
 from scrapy.utils.log import configure_logging
+from scrapy import signals
+from ncsoccer.spiders.schedule_spider import ScheduleSpider
 
 # Configure root logger
 logging.basicConfig(
@@ -244,7 +246,7 @@ def run_scraper(year=None, month=None, day=None, storage_type='s3', bucket_name=
             success = False
 
         # Create the spider
-        spider = NCSoccerSpider(
+        spider = ScheduleSpider(
             date_str=date_str,
             date_dict={'year': year, 'month': month, 'day': day},
             verbose=True
@@ -262,7 +264,7 @@ def run_scraper(year=None, month=None, day=None, storage_type='s3', bucket_name=
             logger.info(f"Scraped item {SpiderTracker.games_count}: {item.get('home_team')} vs {item.get('away_team')}")
 
         # Configure crawler with callbacks
-        crawler = process.create_crawler(NCSoccerSpider)
+        crawler = process.create_crawler(ScheduleSpider)
         crawler.signals.connect(spider_closed, signal=signals.spider_closed)
         crawler.signals.connect(item_scraped, signal=signals.item_scraped)
 


### PR DESCRIPTION
This PR fixes the issue where the runner.py file was referencing a non-existent NCSoccerSpider class. This resolves the execution failures in the Step Function where the Lambda was failing with 'name NCSoccerSpider is not defined'. Changes include: 1) Replaced NCSoccerSpider with ScheduleSpider in runner.py 2) Updated imports to include the correct class 3) Updated CHANGELOG.md to reflect the fix (version 2.14.2)