### PR TITLE
Fix read-only filesystem errors in Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.3] - 2025-03-25
+### Fixed
+- Resolved "Read-only file system: 'data'" error in Lambda function by ensuring all path prefixes use /tmp in Lambda environment
+- Added explicit path adjustments in run_scraper, run_month, and run_date_range functions to handle Lambda's filesystem restrictions
+- Improved logging to show path adjustments made for Lambda environment
+
 ## [2.14.2] - 2025-03-25
 ### Fixed
 - Fixed the runner.py file to use the correct ScheduleSpider class instead of non-existent NCSoccerSpider

--- a/scraping/ncsoccer/runner.py
+++ b/scraping/ncsoccer/runner.py
@@ -172,6 +172,19 @@ def run_scraper(year=None, month=None, day=None, storage_type='s3', bucket_name=
             if not bucket_name:
                 bucket_name = os.environ.get('DATA_BUCKET', 'ncsh-app-data')
 
+            # Ensure directories start with /tmp in Lambda to avoid read-only filesystem errors
+            if not html_prefix.startswith('/tmp/') and not html_prefix.startswith('s3://'):
+                html_prefix = f'/tmp/{html_prefix}'
+                logger.info(f"Adjusted html_prefix for Lambda: {html_prefix}")
+
+            if not json_prefix.startswith('/tmp/') and not json_prefix.startswith('s3://'):
+                json_prefix = f'/tmp/{json_prefix}'
+                logger.info(f"Adjusted json_prefix for Lambda: {json_prefix}")
+
+            if not lookup_file.startswith('/tmp/') and not lookup_file.startswith('s3://'):
+                lookup_file = f'/tmp/{lookup_file}'
+                logger.info(f"Adjusted lookup_file for Lambda: {lookup_file}")
+
         # Get current date for defaults
         now = datetime.now()
         year = year or now.year
@@ -359,6 +372,19 @@ def run_month(year=None, month=None, storage_type='s3', bucket_name=None,
         # Get bucket name from environment if not provided and we're in Lambda
         if not bucket_name:
             bucket_name = os.environ.get('DATA_BUCKET', 'ncsh-app-data')
+
+        # Ensure directories start with /tmp in Lambda to avoid read-only filesystem errors
+        if not html_prefix.startswith('/tmp/') and not html_prefix.startswith('s3://'):
+            html_prefix = f'/tmp/{html_prefix}'
+            logger.info(f"Adjusted html_prefix for Lambda: {html_prefix}")
+
+        if not json_prefix.startswith('/tmp/') and not json_prefix.startswith('s3://'):
+            json_prefix = f'/tmp/{json_prefix}'
+            logger.info(f"Adjusted json_prefix for Lambda: {json_prefix}")
+
+        if not lookup_file.startswith('/tmp/') and not lookup_file.startswith('s3://'):
+            lookup_file = f'/tmp/{lookup_file}'
+            logger.info(f"Adjusted lookup_file for Lambda: {lookup_file}")
 
     # Validate architecture_version
     if architecture_version not in ('v1', 'v2'):
@@ -672,6 +698,19 @@ def run_date_range(start_date, end_date, storage_type='s3', bucket_name=None,
         # Get bucket name from environment if not provided and we're in Lambda
         if not bucket_name:
             bucket_name = os.environ.get('DATA_BUCKET', 'ncsh-app-data')
+
+        # Ensure directories start with /tmp in Lambda to avoid read-only filesystem errors
+        if not html_prefix.startswith('/tmp/') and not html_prefix.startswith('s3://'):
+            html_prefix = f'/tmp/{html_prefix}'
+            logger.info(f"Adjusted html_prefix for Lambda: {html_prefix}")
+
+        if not json_prefix.startswith('/tmp/') and not json_prefix.startswith('s3://'):
+            json_prefix = f'/tmp/{json_prefix}'
+            logger.info(f"Adjusted json_prefix for Lambda: {json_prefix}")
+
+        if not lookup_file.startswith('/tmp/') and not lookup_file.startswith('s3://'):
+            lookup_file = f'/tmp/{lookup_file}'
+            logger.info(f"Adjusted lookup_file for Lambda: {lookup_file}")
 
     current = start_date
     failed_dates = []


### PR DESCRIPTION
This PR resolves the 'Read-only file system: data' error in Lambda functions by ensuring all path prefixes use /tmp in the Lambda environment. Changes include: 1) Added explicit path adjustments in run_scraper, run_month, and run_date_range functions 2) Improved logging to show path adjustments made for Lambda environment 3) Updated CHANGELOG.md to reflect these changes (version 2.14.3)