### PR TITLE
Improve spider performance by reducing download delay and retry times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,3 +344,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed IAM role permissions for Lambda S3 access
 - Updated AWS API endpoint handling
+
+## [2.14.7] - 2025-03-27
+### Improved
+- Reduced spider `DOWNLOAD_DELAY` from 2 seconds to 1 second to speed up the scraping process
+- Reduced `RETRY_TIMES` from 5 to 2 to prevent overly long-running crawls when failures occur
+- These changes improve Lambda performance while maintaining reliability

--- a/scraping/ncsoccer/spiders/schedule_spider.py
+++ b/scraping/ncsoccer/spiders/schedule_spider.py
@@ -47,7 +47,7 @@ class ScheduleSpider(scrapy.Spider):
         'ROBOTSTXT_OBEY': False,
         'COOKIES_ENABLED': True,
         'COOKIES_DEBUG': True,
-        'DOWNLOAD_DELAY': 2,  # Increased to avoid rate limiting
+        'DOWNLOAD_DELAY': 1,  # Reduced from 2 to 1 second to speed up processing
         'CONCURRENT_REQUESTS': 1,
         'DEFAULT_REQUEST_HEADERS': {
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
@@ -64,7 +64,7 @@ class ScheduleSpider(scrapy.Spider):
             'sec-ch-ua-platform': '"macOS"'
         },
         'RETRY_ENABLED': True,
-        'RETRY_TIMES': 5,  # Increased for better reliability
+        'RETRY_TIMES': 2,  # Reduced from 5 to 2 to prevent long-running crawls
         'RETRY_HTTP_CODES': [500, 502, 503, 504, 408, 429, 403]
     }
 


### PR DESCRIPTION
This PR optimizes the ScheduleSpider performance by reducing the download delay from 2 seconds to 1 second and reducing retry times from 5 to 2. These changes help prevent long-running crawls and improve Lambda execution time while maintaining reliability.