### PR TITLE
Add function.zip to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ test_data/
 conversation_history.txt
 *-ui.json
 matches.parquet
+function.zip
 
 # Terraform
 .terraform/


### PR DESCRIPTION
This PR adds function.zip to the project's .gitignore file to prevent accidentally committing Lambda deployment packages to the repository.