### PR TITLE
Fix bs4 dependency issue in Lambda function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.2] - 2025-03-30
+### Fixed
+- Fixed Lambda function dependency issue with BeautifulSoup4 by explicitly installing the package
+- Ensured bs4 module is properly available in the Lambda environment
+- Updated Docker build process to explicitly install BeautifulSoup4
+
 ## [2.15.1] - 2025-03-30
 ### Added
 - Added new logging improvements for better troubleshooting

--- a/scraping/Dockerfile
+++ b/scraping/Dockerfile
@@ -12,6 +12,9 @@ COPY requirements.txt ${LAMBDA_TASK_ROOT}
 # Install Python dependencies
 RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt
 
+# Explicitly install BeautifulSoup4 to ensure bs4 module is available
+RUN pip install beautifulsoup4==4.13.3
+
 # Copy package files and setup
 COPY . ${LAMBDA_TASK_ROOT}
 


### PR DESCRIPTION
This PR fixes the Lambda function dependency issue with BeautifulSoup4 by explicitly installing the package in the Dockerfile. It ensures the bs4 module is properly available in the Lambda environment. The issue was causing Lambda function failures with 'No module named bs4' errors.