### PR TITLE
Add v2 architecture path support for processing Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.15.7] - 2025-04-03
+### Added
+- Added v2 architecture path support for Parquet files in processing Lambda
+- Improved path handling for both v1 and v2 architecture versions
+- Updated unit tests to verify correct path selection based on architecture version
+- Enhanced error handling in JSON to Parquet conversion
+
 ## [2.15.6] - 2025-04-02
 ### Fixed
 - Fixed URL construction in `get_direct_date_url` by adding the required `title` parameter


### PR DESCRIPTION
This PR adds support for v2 architecture paths in the processing Lambda function, improving how Parquet files are stored and accessed.