### PR TITLE
Fix Step Function to support v2 architecture paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.15.8] - 2025-04-04
+### Fixed
+- Updated Step Function definition to correctly handle v2 architecture paths
+- Removed hardcoded path prefixes to allow Lambda to determine the correct paths based on architecture_version
+- Improved Step Function compatibility with v2 directory structure
+- Ensured proper Parquet file generation in v2 architecture mode
+
 ## [2.15.7] - 2025-04-03
 ### Added
 - Added v2 architecture path support for Parquet files in processing Lambda

--- a/terraform/infrastructure/unified-workflow-batched.asl.json
+++ b/terraform/infrastructure/unified-workflow-batched.asl.json
@@ -135,9 +135,7 @@
         "Payload": {
           "operation": "process_all",
           "src_bucket.$": "$.validated_input.Payload.bucket_name",
-          "src_prefix": "data/json/",
           "dst_bucket.$": "$.validated_input.Payload.bucket_name",
-          "dst_prefix": "data/parquet/",
           "date_range": {
             "start_date.$": "$.validated_input.Payload.start_date",
             "end_date.$": "$.validated_input.Payload.end_date"
@@ -159,7 +157,7 @@
           "Next": "HandleProcessingFailure"
         }
       ],
-      "ResultPath": "$.processing_result",
+      "ResultPath": "$.processing",
       "Next": "WorkflowSuccess"
     },
 


### PR DESCRIPTION
This PR fixes the Step Function definition to correctly support v2 architecture paths by removing hardcoded path prefixes and allowing the Lambda function to determine the correct paths based on the architecture_version parameter.