### PR TITLE
Fix meta.json processing in Lambda function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.15.9] - 2025-04-05
+### Fixed
+- Enhanced JSON file filtering in processing Lambda to exclude meta.json files
+- Fixed "If using all scalar values, you must pass an index" error when processing v2 architecture files
+- Improved logging to show when metadata files are being skipped
+- Ensures proper Parquet file generation by focusing only on valid tabular game data
+
 ## [2.15.8] - 2025-04-04
 ### Fixed
 - Updated Step Function definition to correctly handle v2 architecture paths

--- a/processing/lambda_function.py
+++ b/processing/lambda_function.py
@@ -349,7 +349,8 @@ def convert_to_parquet(src_bucket, files, dst_bucket, dst_prefix, version: Optio
 
 def list_json_files(bucket: str, prefix: str, only_recent: bool = True) -> List[str]:
     """
-    List JSON files in the specified S3 bucket and prefix
+    List JSON files in the specified S3 bucket and prefix,
+    excluding metadata files
 
     If only_recent is True, only returns files modified since the last processing run
     """
@@ -378,6 +379,11 @@ def list_json_files(bucket: str, prefix: str, only_recent: bool = True) -> List[
                         naive_last_processed = last_processed.replace(tzinfo=None) if last_processed.tzinfo else last_processed
                         if naive_last_modified <= naive_last_processed:
                             continue
+
+                    # Filter out meta.json files
+                    if key.endswith('meta.json'):
+                        logger.info(f"Skipping metadata file: {key}")
+                        continue
 
                     if key.endswith('.json') or key.endswith('.jsonl'):
                         files.append(key)

--- a/tests/unit/processing/test_list_json_files.py
+++ b/tests/unit/processing/test_list_json_files.py
@@ -1,0 +1,40 @@
+import os
+import json
+import io
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+from processing import lambda_function
+
+
+def test_list_json_files_excludes_meta_json():
+    """Test that list_json_files properly excludes meta.json files"""
+
+    # Mock S3 paginator with both games.jsonl and meta.json files
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {
+            'Contents': [
+                {'Key': 'v2/processed/json/year=2025/month=02/day=15/games.jsonl', 'LastModified': datetime(2025, 4, 5, 12, 0, 0)},
+                {'Key': 'v2/processed/json/year=2025/month=02/day=15/meta.json', 'LastModified': datetime(2025, 4, 5, 12, 0, 0)},
+                {'Key': 'v2/processed/json/year=2025/month=02/day=16/games.jsonl', 'LastModified': datetime(2025, 4, 5, 12, 0, 0)}
+            ]
+        }
+    ]
+
+    # Mock S3 client
+    mock_s3_client = MagicMock()
+    mock_s3_client.get_paginator.return_value = mock_paginator
+    mock_s3_client.get_object.return_value = {
+        'Body': io.BytesIO(json.dumps({'timestamp': '2025-04-01T00:00:00Z'}).encode())
+    }
+
+    # Patch boto3.client to return our mock
+    with patch('processing.lambda_function.boto3.client', return_value=mock_s3_client):
+        # Call the list_json_files function
+        files = lambda_function.list_json_files('test-bucket', 'v2/processed/json/', only_recent=False)
+
+        # Verify meta.json is excluded
+        assert len(files) == 2
+        assert 'meta.json' not in str(files)
+        assert all('games.jsonl' in file for file in files)


### PR DESCRIPTION
This PR fixes the issue where the processing Lambda was attempting to process meta.json files, causing the 'If using all scalar values, you must pass an index' error. This addresses the issue with JSON to Parquet conversion in the v2 architecture.