### PR TITLE
Fix handling of alternative JSON format in Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.16.1] - 2025-04-06
+### Fixed
+- Enhanced validate_and_transform_data function to handle alternative data formats in games.jsonl
+- Added support for parsing score strings ("7 - 2") into separate home and away scores
+- Improved field mapping between different source data formats and the Game schema
+- Fixed issue where valid game data was not being properly processed due to format mismatch
+
+## [2.16.0] - 2025-04-05
+### Added
+- Enhanced validate_and_transform_data function to handle alternative JSON format found in games.jsonl
+- Added support for parsing combined score strings (e.g., "7 - 2") into separate home and away scores
+- Improved field mapping between different data formats and the internal data model
+
 ## [2.15.9] - 2025-04-05
 ### Fixed
 - Enhanced JSON file filtering in processing Lambda to exclude meta.json files

--- a/tests/unit/processing/test_validate_transform.py
+++ b/tests/unit/processing/test_validate_transform.py
@@ -1,0 +1,107 @@
+import pytest
+from processing.lambda_function import validate_and_transform_data
+from datetime import datetime, timezone
+
+def test_validate_transform_alternative_format():
+    """Test that validate_and_transform_data can handle the alternative format with league_name and game_date."""
+    # Example of alternative format data (from games.jsonl)
+    alternative_data = [
+        {
+            "league_name": "Cleveland Select Spring 2025",
+            "game_date": "2025-02-15",
+            "home_team": "Hudson United Tall Ships DB",
+            "away_team": "Cleveland Select U8",
+            "score": "7 - 2",
+            "game_time": "10:00 AM",
+            "field": "Field 3",
+            "url": "https://example.com/games/123",
+            "game_type": "regular",
+            "status": 1.0
+        }
+    ]
+
+    # Run the validation and transformation
+    result = validate_and_transform_data(alternative_data)
+
+    # Verify the results
+    assert len(result) == 1, "Should have one valid record"
+
+    # Check field mappings
+    record = result[0]
+    assert isinstance(record["date"], datetime), "Date should be a datetime object"
+    assert record["date"].strftime("%Y-%m-%d") == "2025-02-15"
+    assert record["home_team"] == "Hudson United Tall Ships DB"
+    assert record["away_team"] == "Cleveland Select U8"
+    assert record["home_score"] == 7
+    assert record["away_score"] == 2
+    assert record["league"] == "Cleveland Select Spring 2025"
+    assert record["time"] == "10:00 AM"
+    assert record["url"] == "https://example.com/games/123"
+    assert record["type"] == "regular"
+    assert record["status"] == 1.0
+
+def test_validate_transform_standard_format():
+    """Test that validate_and_transform_data still works with the standard format."""
+    # Example of standard format data
+    standard_data = [
+        {
+            "date": "2025-02-15",
+            "games": {
+                "home_team": "Hudson United Tall Ships DB",
+                "away_team": "Cleveland Select U8",
+                "home_score": 7,
+                "away_score": 2,
+                "league": "Cleveland Select Spring 2025",
+                "time": "10:00 AM"
+            },
+            "url": "https://example.com/games/123",
+            "type": "regular",
+            "status": 1.0
+        }
+    ]
+
+    # Run the validation and transformation
+    result = validate_and_transform_data(standard_data)
+
+    # Verify the results
+    assert len(result) == 1, "Should have one valid record"
+
+    # Check field mappings
+    record = result[0]
+    assert isinstance(record["date"], datetime), "Date should be a datetime object"
+    assert record["date"].strftime("%Y-%m-%d") == "2025-02-15"
+    assert record["home_team"] == "Hudson United Tall Ships DB"
+    assert record["away_team"] == "Cleveland Select U8"
+    assert record["home_score"] == 7
+    assert record["away_score"] == 2
+    assert record["league"] == "Cleveland Select Spring 2025"
+    assert record["time"] == "10:00 AM"
+    assert record["url"] == "https://example.com/games/123"
+    assert record["type"] == "regular"
+    assert record["status"] == 1.0
+
+def test_validate_transform_malformed_score():
+    """Test that validate_and_transform_data handles malformed score values gracefully."""
+    # Example with a malformed score
+    alt_data_with_bad_score = [
+        {
+            "league_name": "Cleveland Select Spring 2025",
+            "game_date": "2025-02-15",
+            "home_team": "Hudson United Tall Ships DB",
+            "away_team": "Cleveland Select U8",
+            "score": "not a score",  # Malformed score
+            "game_time": "10:00 AM",
+            "field": "Field 3"
+        }
+    ]
+
+    # Run the validation and transformation
+    result = validate_and_transform_data(alt_data_with_bad_score)
+
+    # Verify the results
+    assert len(result) == 1, "Should have one valid record even with bad score"
+
+    # Check score fields are None due to parsing failure
+    record = result[0]
+    assert record["home_score"] is None
+    assert record["away_score"] is None


### PR DESCRIPTION
* Enhanced validate_and_transform_data function to handle alternative data formats in games.jsonl files * Added support for parsing score strings ('7 - 2') into separate home and away scores * Improved field mapping between different source data formats and the Game schema * Added comprehensive unit tests for both data formats * Updated CHANGELOG to version 2.16.1 All tests are passing. This fix resolves the issue with valid game data not being processed due to format mismatch.