### PR TITLE
Fix payload size limit error in ProcessBatchesInParallel for large date ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.10] - 2025-03-24
+### Fixed
+- Fixed ProcessBatchesInParallel payload size limit error when processing large date ranges
+- Updated batch verifier to check S3 for processed files instead of relying on batch results
+- Modified state machine to set ResultPath to null for ProcessBatchesInParallel task
+- Improved reliability for processing very large date ranges (multi-year)
+
 ## [3.0.9] - 2025-03-24
 ### Fixed
 - Further reduced Lambda response payload to absolute minimum

--- a/terraform/infrastructure/unified-workflow-batched.asl.json
+++ b/terraform/infrastructure/unified-workflow-batched.asl.json
@@ -57,7 +57,7 @@
       "Type": "Map",
       "ItemsPath": "$.batches.Payload.batches",
       "MaxConcurrency": 5,
-      "ResultPath": "$.batch_results",
+      "ResultPath": null,
       "Parameters": {
         "start_date.$": "$$.Map.Item.Value.start_date",
         "end_date.$": "$$.Map.Item.Value.end_date",
@@ -102,7 +102,10 @@
       "Parameters": {
         "FunctionName": "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_batch_verifier",
         "Payload": {
-          "batch_results.$": "$.batch_results"
+          "start_date.$": "$.validated_input.Payload.start_date",
+          "end_date.$": "$.validated_input.Payload.end_date",
+          "bucket_name.$": "$.validated_input.Payload.bucket_name",
+          "architecture_version.$": "$.validated_input.Payload.architecture_version"
         }
       },
       "ResultPath": "$.verification",


### PR DESCRIPTION
## Changes

- Fixed ProcessBatchesInParallel payload size limit error when processing large date ranges
- Updated batch verifier to check S3 for processed files instead of relying on batch results
- Modified state machine to set ResultPath to null for ProcessBatchesInParallel task
- Improved reliability for processing very large date ranges (multi-year)

## Testing
- Tested with large date range (2010-01-01 to 2012-12-31)