### PR TITLE
Fix payload size limit for large date ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.11] - 2025-03-24
+### Fixed
+- Modified scraper Lambda to store detailed batch results in S3 instead of returning them directly
+- Increased batch verifier Lambda timeout to 60 seconds and memory to 256MB
+- Updated batch verifier to handle both S3 references and direct S3 checks
+- Improved reliability for processing very large date ranges (multi-year)
+
 ## [3.0.10] - 2025-03-24
 ### Fixed
 - Fixed ProcessBatchesInParallel payload size limit error when processing large date ranges

--- a/terraform/infrastructure/lambda-batched.tf
+++ b/terraform/infrastructure/lambda-batched.tf
@@ -155,8 +155,8 @@ resource "aws_lambda_function" "ncsoccer_batch_verifier" {
   function_name = "ncsoccer_batch_verifier"
   role          = aws_iam_role.lambda_utils_role.arn
   package_type  = "Image"
-  timeout       = 10
-  memory_size   = 128
+  timeout       = 60
+  memory_size   = 256
 
   # This will be updated by the CI/CD pipeline
   image_uri = "${data.aws_ecr_repository.ncsoccer_utils.repository_url}:latest"

--- a/utils/src/batch_verifier.py
+++ b/utils/src/batch_verifier.py
@@ -10,17 +10,17 @@ logger.setLevel(logging.INFO)
 
 def handler(event, context):
     """
-    Verifies all batches completed successfully by checking S3 for processed files
-    instead of relying on batch_results from the state machine
+    Verifies all batches completed successfully by checking batch results or S3 directly
 
     Args:
-        event (dict): Contains start_date, end_date, bucket_name, and architecture_version
+        event (dict): Contains batch_results, start_date, end_date, bucket_name, and architecture_version
 
     Returns:
         dict: Verification result
     """
     try:
         # Extract parameters from the event
+        batch_results = event.get('batch_results', [])
         start_date = event.get('start_date')
         end_date = event.get('end_date')
         bucket_name = event.get('bucket_name', 'ncsh-app-data')
@@ -39,39 +39,98 @@ def handler(event, context):
         # Initialize S3 client
         s3 = boto3.client('s3')
         
-        # Check for processed files in S3
+        # Check if we have batch results with S3 references
+        s3_result_keys = []
+        for batch in batch_results:
+            # Extract the Payload from each batch result
+            payload = batch.get('Payload', {})
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    logger.warning(f"Could not parse batch result payload: {payload}")
+                    continue
+            
+            # Get the body from the payload
+            body = payload.get('body', '{}')
+            if isinstance(body, str):
+                try:
+                    body = json.loads(body)
+                except json.JSONDecodeError:
+                    logger.warning(f"Could not parse batch result body: {body}")
+                    continue
+            
+            # Check if the body contains a reference to S3 results
+            if 'results_s3_key' in body and 'results_s3_bucket' in body:
+                s3_result_keys.append({
+                    'bucket': body['results_s3_bucket'],
+                    'key': body['results_s3_key']
+                })
+                logger.info(f"Found S3 reference to batch results: s3://{body['results_s3_bucket']}/{body['results_s3_key']}")
+        
+        # If we have S3 references, fetch detailed results from S3
         processed_dates = []
         missing_dates = []
         
-        current_dt = start_dt
-        while current_dt <= end_dt:
-            year = current_dt.year
-            month = current_dt.month
-            day = current_dt.day
+        if s3_result_keys:
+            logger.info(f"Found {len(s3_result_keys)} S3 references to batch results")
             
-            # Construct the S3 prefix for this date
-            prefix = f"{architecture_version}/processed/json/year={year}/month={month:02d}/day={day:02d}/"
+            # Fetch detailed results from S3
+            for s3_ref in s3_result_keys:
+                try:
+                    response = s3.get_object(
+                        Bucket=s3_ref['bucket'],
+                        Key=s3_ref['key']
+                    )
+                    detailed_results = json.loads(response['Body'].read().decode('utf-8'))
+                    
+                    # Extract processed dates from detailed results
+                    if 'detailed_results' in detailed_results:
+                        for date_str, success in detailed_results['detailed_results'].items():
+                            if success:
+                                processed_dates.append(date_str)
+                            else:
+                                missing_dates.append(date_str)
+                except Exception as e:
+                    logger.error(f"Error fetching batch results from S3: {str(e)}")
+        
+        # If we don't have S3 references or couldn't fetch them, check S3 directly
+        if not s3_result_keys or not (processed_dates or missing_dates):
+            logger.info("No S3 references found or no results extracted, checking S3 directly")
             
-            try:
-                # Check if files exist for this date
-                response = s3.list_objects_v2(
-                    Bucket=bucket_name,
-                    Prefix=prefix,
-                    MaxKeys=1
-                )
+            # Reset processed and missing dates
+            processed_dates = []
+            missing_dates = []
+            
+            current_dt = start_dt
+            while current_dt <= end_dt:
+                year = current_dt.year
+                month = current_dt.month
+                day = current_dt.day
                 
-                if 'Contents' in response and len(response['Contents']) > 0:
-                    processed_dates.append(current_dt.strftime('%Y-%m-%d'))
-                    logger.info(f"Found processed files for {current_dt.strftime('%Y-%m-%d')}")
-                else:
+                # Construct the S3 prefix for this date
+                prefix = f"{architecture_version}/processed/json/year={year}/month={month:02d}/day={day:02d}/"
+                
+                try:
+                    # Check if files exist for this date
+                    response = s3.list_objects_v2(
+                        Bucket=bucket_name,
+                        Prefix=prefix,
+                        MaxKeys=1
+                    )
+                    
+                    if 'Contents' in response and len(response['Contents']) > 0:
+                        processed_dates.append(current_dt.strftime('%Y-%m-%d'))
+                        logger.info(f"Found processed files for {current_dt.strftime('%Y-%m-%d')}")
+                    else:
+                        missing_dates.append(current_dt.strftime('%Y-%m-%d'))
+                        logger.warning(f"No processed files found for {current_dt.strftime('%Y-%m-%d')}")
+                except Exception as e:
+                    logger.error(f"Error checking S3 for {current_dt.strftime('%Y-%m-%d')}: {str(e)}")
                     missing_dates.append(current_dt.strftime('%Y-%m-%d'))
-                    logger.warning(f"No processed files found for {current_dt.strftime('%Y-%m-%d')}")
-            except Exception as e:
-                logger.error(f"Error checking S3 for {current_dt.strftime('%Y-%m-%d')}: {str(e)}")
-                missing_dates.append(current_dt.strftime('%Y-%m-%d'))
-            
-            # Move to the next day
-            current_dt += timedelta(days=1)
+                
+                # Move to the next day
+                current_dt += timedelta(days=1)
         
         # Determine success based on whether all dates were processed
         success = len(missing_dates) == 0


### PR DESCRIPTION
This PR fixes the payload size limit issue when processing large date ranges by:

1. Modified scraper Lambda to store detailed batch results in S3 instead of returning them directly
2. Increased batch verifier Lambda timeout to 60 seconds and memory to 256MB
3. Updated batch verifier to handle both S3 references and direct S3 checks
4. Improved reliability for processing very large date ranges (multi-year)

This approach is similar to the fix we previously implemented for the processing Lambda function.