### PR TITLE
Fix Terraform configuration for recursive workflow Lambda functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.15] - 2025-03-24
+### Fixed
+- Fixed Terraform configuration for recursive workflow Lambda functions
+- Added missing ncsoccer_execution_checker Lambda function definition
+- Updated ncsoccer_date_range_splitter to use the correct state machine ARN
+- Updated IAM permissions to allow Lambda functions to interact with the recursive state machine
+
 ## [3.0.14] - 2025-03-24
 ### Fixed
 - Updated GitHub workflow to deploy new recursive workflow Lambda functions

--- a/terraform/infrastructure/lambda-batched.tf
+++ b/terraform/infrastructure/lambda-batched.tf
@@ -115,7 +115,9 @@ resource "aws_iam_role_policy" "lambda_utils_policy" {
         ],
         Resource = [
           "arn:aws:states:us-east-2:*:stateMachine:ncsoccer-unified-workflow-batched",
-          "arn:aws:states:us-east-2:*:execution:ncsoccer-unified-workflow-batched:*"
+          "arn:aws:states:us-east-2:*:execution:ncsoccer-unified-workflow-batched:*",
+          "arn:aws:states:us-east-2:*:stateMachine:ncsoccer-unified-workflow-recursive",
+          "arn:aws:states:us-east-2:*:execution:ncsoccer-unified-workflow-recursive:*"
         ]
       }
     ]
@@ -194,7 +196,25 @@ resource "aws_lambda_function" "ncsoccer_date_range_splitter" {
   environment {
     variables = {
       DATA_BUCKET = "ncsh-app-data"
-      STATE_MACHINE_ARN = aws_sfn_state_machine.ncsoccer_unified_workflow_batched.arn
+      STATE_MACHINE_ARN = aws_sfn_state_machine.ncsoccer_unified_workflow_recursive.arn
+    }
+  }
+}
+
+# Execution Checker Lambda
+resource "aws_lambda_function" "ncsoccer_execution_checker" {
+  function_name = "ncsoccer_execution_checker"
+  role          = aws_iam_role.lambda_utils_role.arn
+  package_type  = "Image"
+  timeout       = 60
+  memory_size   = 256
+
+  # This will be updated by the CI/CD pipeline
+  image_uri = "${data.aws_ecr_repository.ncsoccer_utils.repository_url}:latest"
+
+  environment {
+    variables = {
+      DATA_BUCKET = "ncsh-app-data"
     }
   }
 }


### PR DESCRIPTION
- Fixed Terraform configuration for recursive workflow Lambda functions\n- Added missing ncsoccer_execution_checker Lambda function definition\n- Updated ncsoccer_date_range_splitter to use the correct state machine ARN\n- Updated IAM permissions to allow Lambda functions to interact with the recursive state machine\n- Updated CHANGELOG.md to version 3.0.15 to trigger a new build