### PR TITLE
Fix duplicate resource in Terraform configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.16] - 2025-03-24
+### Fixed
+- Fixed duplicate resource in Terraform configuration
+- Removed duplicate ncsoccer_execution_checker Lambda function definition
+- Added CloudWatch log groups for new Lambda functions
+- Ensured Terraform can be applied without errors
+
 ## [3.0.15] - 2025-03-24
 ### Fixed
 - Fixed Terraform configuration for recursive workflow Lambda functions

--- a/terraform/infrastructure/lambda-batched.tf
+++ b/terraform/infrastructure/lambda-batched.tf
@@ -219,24 +219,6 @@ resource "aws_lambda_function" "ncsoccer_execution_checker" {
   }
 }
 
-# Execution Checker Lambda
-resource "aws_lambda_function" "ncsoccer_execution_checker" {
-  function_name = "ncsoccer_execution_checker"
-  role          = aws_iam_role.lambda_utils_role.arn
-  package_type  = "Image"
-  timeout       = 60
-  memory_size   = 256
-
-  # This will be updated by the CI/CD pipeline
-  image_uri = "${data.aws_ecr_repository.ncsoccer_utils.repository_url}:latest"
-
-  environment {
-    variables = {
-      DATA_BUCKET = "ncsh-app-data"
-    }
-  }
-}
-
 # CloudWatch Log Groups
 resource "aws_cloudwatch_log_group" "ncsoccer_input_validator_logs" {
   name              = "/aws/lambda/${aws_lambda_function.ncsoccer_input_validator.function_name}"
@@ -260,6 +242,26 @@ resource "aws_cloudwatch_log_group" "ncsoccer_batch_planner_logs" {
 
 resource "aws_cloudwatch_log_group" "ncsoccer_batch_verifier_logs" {
   name              = "/aws/lambda/${aws_lambda_function.ncsoccer_batch_verifier.function_name}"
+  retention_in_days = 30
+
+  tags = {
+    Environment = var.environment
+    Project     = "ncsoccer"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ncsoccer_date_range_splitter_logs" {
+  name              = "/aws/lambda/${aws_lambda_function.ncsoccer_date_range_splitter.function_name}"
+  retention_in_days = 30
+
+  tags = {
+    Environment = var.environment
+    Project     = "ncsoccer"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ncsoccer_execution_checker_logs" {
+  name              = "/aws/lambda/${aws_lambda_function.ncsoccer_execution_checker.function_name}"
   retention_in_days = 30
 
   tags = {


### PR DESCRIPTION
- Fixed duplicate resource in Terraform configuration\n- Removed duplicate ncsoccer_execution_checker Lambda function definition\n- Added CloudWatch log groups for new Lambda functions\n- Updated CHANGELOG.md to version 3.0.16 to trigger a new build