### PR TITLE
Fix duplicate CloudWatch log group resources in Terraform configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.0.17] - 2025-03-24
+### Fixed
+- Fixed duplicate CloudWatch log group resources in Terraform configuration
+- Removed duplicate ncsoccer_date_range_splitter_logs and ncsoccer_execution_checker_logs resources
+- Ensured Terraform can be applied without errors
+
 ## [3.0.16] - 2025-03-24
 ### Fixed
 - Fixed duplicate resource in Terraform configuration

--- a/terraform/infrastructure/lambda-batched.tf
+++ b/terraform/infrastructure/lambda-batched.tf
@@ -269,23 +269,3 @@ resource "aws_cloudwatch_log_group" "ncsoccer_execution_checker_logs" {
     Project     = "ncsoccer"
   }
 }
-
-resource "aws_cloudwatch_log_group" "ncsoccer_date_range_splitter_logs" {
-  name              = "/aws/lambda/${aws_lambda_function.ncsoccer_date_range_splitter.function_name}"
-  retention_in_days = 30
-
-  tags = {
-    Environment = var.environment
-    Project     = "ncsoccer"
-  }
-}
-
-resource "aws_cloudwatch_log_group" "ncsoccer_execution_checker_logs" {
-  name              = "/aws/lambda/${aws_lambda_function.ncsoccer_execution_checker.function_name}"
-  retention_in_days = 30
-
-  tags = {
-    Environment = var.environment
-    Project     = "ncsoccer"
-  }
-}


### PR DESCRIPTION
- Fixed duplicate CloudWatch log group resources in Terraform configuration\n- Removed duplicate ncsoccer_date_range_splitter_logs and ncsoccer_execution_checker_logs resources\n- Updated CHANGELOG.md to version 3.0.17 to trigger a new build