### PR TITLE
Fix circular dependency in Terraform configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.18] - 2025-03-24
+### Fixed
+- Fixed circular dependency in Terraform configuration
+- Updated IAM policy to use hardcoded ARNs for Lambda functions
+- Updated Lambda function to use hardcoded ARN for state machine
+- Ensured Terraform can be applied without errors
+
 ## [3.0.17] - 2025-03-24
 ### Fixed
 - Fixed duplicate CloudWatch log group resources in Terraform configuration

--- a/terraform/infrastructure/lambda-batched.tf
+++ b/terraform/infrastructure/lambda-batched.tf
@@ -196,7 +196,7 @@ resource "aws_lambda_function" "ncsoccer_date_range_splitter" {
   environment {
     variables = {
       DATA_BUCKET = "ncsh-app-data"
-      STATE_MACHINE_ARN = aws_sfn_state_machine.ncsoccer_unified_workflow_recursive.arn
+      STATE_MACHINE_ARN = "arn:aws:states:us-east-2:552336166511:stateMachine:ncsoccer-unified-workflow-recursive"
     }
   }
 }

--- a/terraform/infrastructure/unified-workflow-recursive.tf
+++ b/terraform/infrastructure/unified-workflow-recursive.tf
@@ -73,12 +73,12 @@ resource "aws_iam_policy" "unified_workflow_recursive_step_function_policy" {
           "lambda:InvokeFunction"
         ]
         Resource = [
-          aws_lambda_function.ncsoccer_input_validator.arn,
-          aws_lambda_function.ncsoccer_batch_planner.arn,
-          aws_lambda_function.ncsoccer_scraper.arn,
-          aws_lambda_function.ncsoccer_batch_verifier.arn,
-          aws_lambda_function.ncsoccer_date_range_splitter.arn,
-          aws_lambda_function.ncsoccer_execution_checker.arn,
+          "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_input_validator",
+          "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_batch_planner",
+          "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_scraper",
+          "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_batch_verifier",
+          "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_date_range_splitter",
+          "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer_execution_checker",
           "arn:aws:lambda:us-east-2:552336166511:function:ncsoccer-processing"
         ]
       },


### PR DESCRIPTION
- Fixed circular dependency in Terraform configuration\n- Updated IAM policy to use hardcoded ARNs for Lambda functions\n- Updated Lambda function to use hardcoded ARN for state machine\n- Updated CHANGELOG.md to version 3.0.18 to trigger a new build