### PR TITLE
Fix: Disable redundant workflow event rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.0.26] - 2025-03-28
+### Fixed
+- Disabled incorrect EventBridge rules that were triggering the wrong Step Functions
+- Ensured only the recursive workflow is triggered by the daily cron job
+- Prevented failures from non-recursive workflows running in parallel
+
 ## [3.0.25] - 2025-03-27
 ### Fixed
 - Added retry mechanism for Lambda function configuration update in CI/CD pipeline

--- a/terraform/infrastructure/unified-workflow-batched.tf
+++ b/terraform/infrastructure/unified-workflow-batched.tf
@@ -138,7 +138,7 @@ resource "aws_cloudwatch_event_rule" "ncsoccer_daily_unified_batched" {
   description = "Trigger NC Soccer unified batched workflow for current day at 04:00 UTC"
 
   schedule_expression = "cron(0 4 * * ? *)"
-  state               = "ENABLED" # Enable daily workflow
+  state               = "DISABLED" # Disabled in favor of recursive workflow
 
   tags = {
     Environment = var.environment

--- a/terraform/infrastructure/unified-workflow.tf
+++ b/terraform/infrastructure/unified-workflow.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_event_rule" "ncsoccer_daily_unified" {
   description = "Trigger NC Soccer unified workflow for current day at 04:00 UTC"
 
   schedule_expression = "cron(0 4 * * ? *)"
-  state               = "ENABLED"
+  state               = "DISABLED" # Disabled in favor of recursive workflow
 
   tags = {
     Environment = var.environment


### PR DESCRIPTION
## Summary
- Disabled daily unified and daily unified batched workflow EventBridge rules to prevent conflicts with the recursive workflow
- Updated Terraform configurations to ensure only the recursive workflow is triggered by the daily cron job
- Added CHANGELOG entry documenting the changes

## Test plan
- Verify terraform apply completes successfully
- Confirm only the recursive workflow is being triggered by EventBridge
- Ensure no duplicate workflow executions are happening at the scheduled time

🤖 Generated with [Claude Code](https://claude.ai/code)